### PR TITLE
Add Biz category & update Hero/UX actions

### DIFF
--- a/lib/bbpro/presentation/create_product.dart
+++ b/lib/bbpro/presentation/create_product.dart
@@ -64,6 +64,7 @@ class _CreateProductListingState extends State<CreateProductListing> {
   bool loading = false;
   final List<String> categories = <String>[
     'Agriculture, Food & Beverage',
+    'Business Services & Consulting',
     'Learning & Education',
     'Construction & Real Estate',
     'Fashion & Beauty',

--- a/lib/bbpro/presentation/create_service.dart
+++ b/lib/bbpro/presentation/create_service.dart
@@ -109,6 +109,7 @@ class _CreateServiceListingState extends State<CreateServiceListing>
   final bool _shouldPromote = true;
   final List<String> categories = <String>[
     'Agriculture, Food & Beverage',
+    'Business Services & Consulting',
     'Learning & Education',
     'Construction & Real Estate',
     'Fashion & Beauty',

--- a/lib/bbpro/presentation/setup_shop.dart
+++ b/lib/bbpro/presentation/setup_shop.dart
@@ -91,6 +91,7 @@ class _SetupshopState extends State<Setupshop> with TickerProviderStateMixin {
   };
   final List<String> categories = <String>[
     'Agriculture, Food & Beverage',
+    'Business Services & Consulting',
     'Learning & Education',
     'Construction & Real Estate',
     'Fashion & Beauty',

--- a/lib/features/donations/widgets/donation_item.dart
+++ b/lib/features/donations/widgets/donation_item.dart
@@ -262,7 +262,7 @@ class _DonationItemState extends State<DonationItem> {
                               crossAxisAlignment: CrossAxisAlignment.center,
                               children: <Widget>[
                                 const Text(
-                                  'Visit My Center',
+                                  'Visit My Biz-Center',
                                   style: TextStyle(
                                       color: Color.fromARGB(255, 9, 93, 237),
                                       fontSize: 12),

--- a/lib/features/forum/widgets/forum_item.dart
+++ b/lib/features/forum/widgets/forum_item.dart
@@ -678,7 +678,7 @@ class _ForumItemState extends State<ForumItem> {
                                 crossAxisAlignment: CrossAxisAlignment.center,
                                 children: <Widget>[
                                   const Text(
-                                    'Visit My Center',
+                                    'Visit My Biz-Center',
                                     style: TextStyle(
                                         color: Color.fromARGB(255, 9, 93, 237),
                                         fontSize: 14),

--- a/lib/features/home/widgets/course_item.dart
+++ b/lib/features/home/widgets/course_item.dart
@@ -856,7 +856,7 @@ class _CourseItemState extends State<CourseItem> {
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: <Widget>[
                           const Text(
-                            'Visit My Center',
+                            'Visit My Biz-Center',
                             style: TextStyle(
                                 color: Color.fromARGB(255, 9, 93, 237),
                                 fontSize: 12),

--- a/lib/features/home/widgets/forum_item.dart
+++ b/lib/features/home/widgets/forum_item.dart
@@ -619,7 +619,7 @@ class _ForumItemState extends State<ForumItem> {
                                 crossAxisAlignment: CrossAxisAlignment.center,
                                 children: <Widget>[
                                   const Text(
-                                    'Visit My Center',
+                                    'Visit My Biz-Center',
                                     style: TextStyle(
                                         color: Color.fromARGB(255, 9, 93, 237),
                                         fontSize: 14),

--- a/lib/features/home/widgets/hero_section.dart
+++ b/lib/features/home/widgets/hero_section.dart
@@ -100,7 +100,7 @@ class _HeroSectionState extends State<HeroSection> {
   static const Map<String, WinnerCardConfig> cardConfigs =
       <String, WinnerCardConfig>{
     'boss': WinnerCardConfig(
-      title: 'Boss of the Week',
+      title: 'Top Ranking of the Week',
       icon: LucideIcons.trophy,
       gradientColors: <Color>[backgroundColor, backgroundColor],
       iconColor: Color(0xFFFCD34D),
@@ -144,23 +144,6 @@ class _HeroSectionState extends State<HeroSection> {
       iconColor: Color(0xFF93C5FD),
       accentColor: Color(0x3360A5FA),
     ),
-    'ranking': WinnerCardConfig(
-      title: 'Top Ranked This Week',
-      icon: LucideIcons.trophy,
-      gradientColors: <Color>[backgroundColor, backgroundColor],
-      iconColor: Color(0xFFFCD34D),
-      accentColor: Color(0x33FBBf24),
-    ),
-    'my_ranking': WinnerCardConfig(
-      title: 'Your Reach Ranking',
-      icon: LucideIcons.barChart2,
-      gradientColors: <Color>[
-        Color(0xFFE0F2FE),
-        Color(0xFFE0F2FE),
-      ],
-      iconColor: Colors.blue,
-      accentColor: Colors.blue,
-    ),
   };
 
   @override
@@ -182,20 +165,9 @@ class _HeroSectionState extends State<HeroSection> {
     heroItems = <HeroItem>[
       HeroItem(
         id: '0',
-        type: 'ranking',
-        title: 'Top Ranked This Week',
-        icon: 'assets/images/app_logo_2.png',
-        subtitle: 'Loading...',
-        image: '',
-        description: '',
-        action: 'Follow',
-        action2: 'Get Featured',
-      ),
-      HeroItem(
-        id: '1',
         type: 'boss',
         icon: 'assets/images/app_logo_2.png',
-        title: 'Boss of the Week',
+        title: 'Top Ranking of the Week',
         subtitle: user?.name ?? user!.username,
         description: user?.bio ?? '',
         image: user?.photoUrl ?? '',
@@ -205,7 +177,7 @@ class _HeroSectionState extends State<HeroSection> {
         action2: 'Get Featured',
       ),
       HeroItem(
-        id: '2',
+        id: '1',
         type: 'mentor',
         icon: 'assets/images/app_logo_2.png',
         title: 'Mentor of the Week',
@@ -218,7 +190,7 @@ class _HeroSectionState extends State<HeroSection> {
         action2: 'Share Learning',
       ),
       HeroItem(
-        id: '3',
+        id: '2',
         type: 'backer',
         icon: 'assets/images/app_logo_2.png',
         title: 'Backer of the Week',
@@ -231,7 +203,7 @@ class _HeroSectionState extends State<HeroSection> {
         action2: 'Fund Project',
       ),
       HeroItem(
-        id: '4',
+        id: '3',
         type: 'partner',
         title: 'Partner of the Week',
         icon: 'assets/images/app_logo_2.png',
@@ -242,7 +214,7 @@ class _HeroSectionState extends State<HeroSection> {
         action2: 'Become a Partner',
       ),
       HeroItem(
-        id: '5',
+        id: '4',
         type: 'ambassador',
         title: 'Ambassador of the Week',
         icon: 'assets/images/app_logo_2.png',
@@ -251,18 +223,6 @@ class _HeroSectionState extends State<HeroSection> {
         description: ambassador?.bio ?? '',
         action: 'Follow',
         action2: 'Become Ambassador',
-      ),
-      HeroItem(
-        id: '6',
-        type: 'my_ranking',
-        title: 'Your Reach Ranking',
-        icon: 'assets/images/app_logo_2.png',
-        subtitle: _profileController.myProfile.weeklyRank ?? 'N/A',
-        image: '',
-        description:
-            'Connect with people and opportunities that can help boost your reach and revenue',
-        action: 'View your Match',
-        action2: 'Get Featured',
       ),
     ];
   }
@@ -448,8 +408,30 @@ class _HeroSectionState extends State<HeroSection> {
 
     return GestureDetector(
       onTap: () {
-        if (item.type == 'ranking') {
-          Get.to(() => const LeaderboardScreen());
+        switch (item.type) {
+          case 'boss':
+            Get.to(() => const LeaderboardScreen());
+            break;
+          case 'ranking':
+            Get.to(() => const LeaderboardScreen());
+            break;
+          case 'mentor':
+            Get.to(() => const AllLearningPostsScreen(isCoursesTile: false));
+            break;
+          case 'backer':
+            Get.to(() => DonationsPage(ishome: false));
+            break;
+          case 'partner':
+            Get.to(() => BossUpPartner());
+            break;
+          case 'ambassador':
+            Get.to(Invitepage());
+            break;
+          case 'matches':
+            Get.to(() => const ExpandedMatchesScreen());
+            break;
+          default:
+            break;
         }
       },
       child: Container(
@@ -1008,9 +990,8 @@ class _HeroSectionState extends State<HeroSection> {
           GestureDetector(
             onTap: _onUserInteraction,
             onPanDown: (_) => _onUserInteraction(),
-            // FIXED: Changed IntrinsicHeight to SizedBox with fixed height
             child: SizedBox(
-              height: 185, // Adjust this height as needed
+              height: 185,
               child: PageView.builder(
                 controller: _pageController,
                 itemCount: heroItems.length,
@@ -1022,7 +1003,7 @@ class _HeroSectionState extends State<HeroSection> {
                   final HeroItem item = heroItems[index];
                   final Industry category = challengeController.categories[0];
 
-                  // FIXED: Handle matches card click navigation
+                  // Handle matches card click navigation
                   if (item.type == 'matches') {
                     return GestureDetector(
                       onTap: () {
@@ -1052,64 +1033,8 @@ class _HeroSectionState extends State<HeroSection> {
                       onTap: () {
                         switch (item.type) {
                           case 'boss':
-                            DateTime now = DateTime.now();
-                            if (category.startAt != null &&
-                                now.isBefore(category.startAt!)) {
-                              showDialog(
-                                context: context,
-                                builder: (BuildContext context) {
-                                  return AlertDialog(
-                                    title: const Text(
-                                      'How It Works!',
-                                      style: TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        decoration: TextDecoration.underline,
-                                      ),
-                                      textAlign: TextAlign.center,
-                                    ),
-                                    content: Column(
-                                      mainAxisSize: MainAxisSize.min,
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.center,
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.center,
-                                      children: <Widget>[
-                                        Text(
-                                          category.criteria!,
-                                          textAlign: TextAlign.center,
-                                        ),
-                                        const SizedBox(height: 10),
-                                        Text(
-                                          _calculateStartDate(
-                                            category.startAt!,
-                                          ),
-                                          style: const TextStyle(
-                                            fontSize: 20,
-                                            fontWeight: FontWeight.bold,
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                    actions: <Widget>[
-                                      TextButton(
-                                        child: const Text('OK'),
-                                        onPressed: () {
-                                          Navigator.of(context).pop();
-                                        },
-                                      ),
-                                    ],
-                                  );
-                                },
-                              );
-                              return;
-                            }
-                            Get.to(
-                              () => BossUpSection(
-                                industry: category,
-                                bossUp: challengeController.categories[0],
-                              ),
-                            );
-
+                            // Navigate to LeaderboardScreen when clicking Top Ranking of the Week
+                            Get.to(() => const LeaderboardScreen());
                             break;
                           case 'mentor':
                             Get.to(

--- a/lib/features/marketplace/presentation/buyer_requests_screen.dart
+++ b/lib/features/marketplace/presentation/buyer_requests_screen.dart
@@ -650,13 +650,12 @@ class _BuyerRequestsScreenState extends State<BuyerRequestsScreen> {
   }
 
   Widget _buildEmptyState() {
-    final bool hasBizCenter = profileController.myProfile.hasShop;
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           Icon(
-            hasBizCenter ? LucideIcons.inbox : LucideIcons.bellRing,
+            LucideIcons.bellRing,
             size: 80,
             color: Colors.grey[400],
           ),
@@ -664,9 +663,7 @@ class _BuyerRequestsScreenState extends State<BuyerRequestsScreen> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 40),
             child: Text(
-              hasBizCenter
-                  ? 'No requests found'
-                  : "We'll notify you when we find a customer match for you",
+              "We'll notify you when we find a customer match for you",
               textAlign: TextAlign.center,
               style: TextStyle(
                 fontSize: 18,
@@ -677,9 +674,7 @@ class _BuyerRequestsScreenState extends State<BuyerRequestsScreen> {
           ),
           const SizedBox(height: 8),
           Text(
-            hasBizCenter
-                ? 'Try adjusting your filters'
-                : 'Complete your BizCenter to start matching',
+            'Check back soon for new opportunities',
             style: TextStyle(
               fontSize: 14,
               color: Colors.grey[500],

--- a/lib/features/marketplace/presentation/listing_success_screen.dart
+++ b/lib/features/marketplace/presentation/listing_success_screen.dart
@@ -99,6 +99,9 @@ class _ListingSuccessScreenState extends State<ListingSuccessScreen> {
   }
 
   Widget _buildSuccessHeader() {
+    // Determine if we should show the matching message
+    final bool hasResults = !isLoading && results.isNotEmpty;
+
     return Column(
       children: <Widget>[
         Container(
@@ -127,8 +130,12 @@ class _ListingSuccessScreenState extends State<ListingSuccessScreen> {
           padding: const EdgeInsets.symmetric(horizontal: 40),
           child: Text(
             widget.isBuyerRequest
-                ? 'Your request is now live. Here are some suppliers who can help.'
-                : 'Your listing is now live. Here are some buyers looking for what you offer.',
+                ? hasResults
+                    ? 'Your request is now live. Here are some suppliers who can help.'
+                    : 'Your request is now live.'
+                : hasResults
+                    ? 'Your listing is now live. Here are some buyers looking for what you offer.'
+                    : 'Your listing is now live.',
             textAlign: TextAlign.center,
             style: TextStyle(
               color: textColor.withValues(alpha: 0.6),

--- a/lib/features/matching_feature/presentation/expanded_matches_screen.dart
+++ b/lib/features/matching_feature/presentation/expanded_matches_screen.dart
@@ -1,6 +1,5 @@
 // Import your controllers and other necessary files
-import 'package:business_bosses_v2/bbpro/presentation/create_product.dart';
-import 'package:business_bosses_v2/bbpro/presentation/create_service.dart';
+import 'package:business_bosses_v2/bbpro/presentation/proshopdealsscreen.dart';
 import 'package:business_bosses_v2/common/models/user_model.dart';
 import 'package:business_bosses_v2/common/widgets/safety_model.dart';
 import 'package:business_bosses_v2/features/courses/presentation/create_course.dart';
@@ -19,6 +18,7 @@ import 'package:business_bosses_v2/features/matching_feature/widgets/match_heade
 import 'package:business_bosses_v2/features/matching_feature/widgets/pre_match_modal.dart';
 import 'package:business_bosses_v2/features/matching_feature/widgets/premium_prompt.dart';
 import 'package:business_bosses_v2/features/partners/presentation/boss_up_partner.dart';
+import 'package:business_bosses_v2/features/premium/proscreen.dart';
 import 'package:business_bosses_v2/features/profile/controller/profile_controller.dart';
 import 'package:business_bosses_v2/navigation/routes.dart';
 import 'package:business_bosses_v2/utils/constants/constants.dart';
@@ -363,11 +363,20 @@ class _ExpandedMatchesScreenState extends State<ExpandedMatchesScreen>
                   ),
                   const SizedBox(width: 10),
                   Expanded(
-                    child: _buildPopupMenuActionCard(
+                    child: _buildActionCard(
                       title: 'Get Listing Featured',
                       icon: LucideIcons.star,
                       color: Colors.amber,
-                      context: context,
+                      onTap: () {
+                        // Check if user has Pro/BizCenter
+                        if (profileController.myProfile.hasShop) {
+                          // User has Pro - go to featured listings screen
+                          Get.to(() => const ProshopdealsScreen());
+                        } else {
+                          // User doesn't have Pro - go to upgrade screen
+                          Get.to(() => const ProScreen());
+                        }
+                      },
                     ),
                   ),
                 ] else if (isInvestor) ...<Widget>[
@@ -469,14 +478,6 @@ class _ExpandedMatchesScreenState extends State<ExpandedMatchesScreen>
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(14),
           color: Colors.white,
-          border: Border.all(color: Colors.grey.shade200),
-          boxShadow: <BoxShadow>[
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.05),
-              blurRadius: 6,
-              offset: const Offset(0, 3),
-            )
-          ],
         ),
         child: Row(
           children: <Widget>[
@@ -484,12 +485,12 @@ class _ExpandedMatchesScreenState extends State<ExpandedMatchesScreen>
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: color.withValues(alpha: 0.1),
+                color: color.withValues(alpha: 0.15),
               ),
               child: Icon(
                 icon,
                 color: color,
-                size: 18,
+                size: 20,
               ),
             ),
             const SizedBox(width: 8),
@@ -498,121 +499,7 @@ class _ExpandedMatchesScreenState extends State<ExpandedMatchesScreen>
                 title,
                 style: TextStyle(
                   fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.grey.shade900,
-                ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPopupMenuActionCard({
-    required String title,
-    required IconData icon,
-    required Color color,
-    required BuildContext context,
-  }) {
-    return PopupMenuButton<String>(
-      offset: const Offset(0, 80),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(10.0),
-      ),
-      onSelected: (String value) {
-        if (value == 'product') {
-          Get.to(() => const CreateProductListing());
-        } else if (value == 'service') {
-          Get.to(() => const CreateServiceListing());
-        }
-      },
-      itemBuilder: (BuildContext context) {
-        return <PopupMenuEntry<String>>[
-          PopupMenuItem<String>(
-            value: 'product',
-            child: Row(
-              children: <Widget>[
-                SvgPicture.asset(
-                  'assets/svgs/addproduct.svg',
-                  colorFilter: const ColorFilter.mode(
-                    textColor,
-                    BlendMode.srcIn,
-                  ),
-                  height: 15,
-                ),
-                const SizedBox(width: 8),
-                const Text(
-                  'Create a Product',
-                  style: TextStyle(
-                    fontSize: 13,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          PopupMenuItem<String>(
-            value: 'service',
-            child: Row(
-              children: <Widget>[
-                SvgPicture.asset(
-                  'assets/svgs/addservice.svg',
-                  height: 15,
-                  colorFilter: const ColorFilter.mode(
-                    textColor,
-                    BlendMode.srcIn,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                const Text(
-                  'Create a Service',
-                  style: TextStyle(
-                    fontSize: 13,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ];
-      },
-      child: Container(
-        height: 80,
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(14),
-          color: Colors.white,
-          border: Border.all(color: Colors.grey.shade200),
-          boxShadow: <BoxShadow>[
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.05),
-              blurRadius: 6,
-              offset: const Offset(0, 3),
-            )
-          ],
-        ),
-        child: Row(
-          children: <Widget>[
-            Container(
-              padding: const EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: color.withValues(alpha: 0.1),
-              ),
-              child: Icon(
-                icon,
-                color: color,
-                size: 18,
-              ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                title,
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
+                  fontWeight: FontWeight.w700,
                   color: Colors.grey.shade900,
                 ),
                 maxLines: 2,

--- a/lib/features/posts/widgets/userpost_tile.dart
+++ b/lib/features/posts/widgets/userpost_tile.dart
@@ -575,7 +575,7 @@ class _PostTileState extends State<PostTile> {
                             crossAxisAlignment: CrossAxisAlignment.center,
                             children: <Widget>[
                               const Text(
-                                'Visit My Center',
+                                'Visit My Biz-Center',
                                 style: TextStyle(
                                     color: Color.fromARGB(255, 9, 93, 237),
                                     fontSize: 14),

--- a/lib/features/profile/presentation/update_profile_screen.dart
+++ b/lib/features/profile/presentation/update_profile_screen.dart
@@ -84,6 +84,7 @@ class _UpdateProfileScreenState extends State<UpdateProfileScreen> {
   List<String> achievements = <String>[];
   final List<String> categories = <String>[
     'Agriculture, Food & Beverage',
+    'Business Services & Consulting',
     'Learning & Education',
     'Construction & Real Estate',
     'Fashion & Beauty',


### PR DESCRIPTION
Add 'Business Services & Consulting' to several category lists (create product/service, setup shop, update profile). Update multiple UI labels from "Visit My Center" to "Visit My Biz-Center" across donations, forum, course, home and post widgets. Revamp HeroSection: rename card title to "Top Ranking of the Week", remove redundant ranking/my_ranking configs, reindex hero item ids, enforce PageView height, and replace the single if with a switch to route card taps to appropriate screens (leaderboard, learning, donations, partners, invites, matches, etc.). Simplify the boss tap flow to navigate to the leaderboard. Buyer requests empty state: remove conditional hasBizCenter usage, simplify icon and copy to a generic waiting message. Listing success: conditionally adjust header text based on whether matching results exist. Expanded matches screen: replace product/service popup with a single action card that routes to ProshopdealsScreen if the user has a shop, otherwise to ProScreen; adjust visual styling (icon size, alpha, font weight) and clean up related imports and unused popup code.